### PR TITLE
Correcting error handler in Export-ADHuntingACLDefaultFromSchema funct

### DIFF
--- a/FarsightAD.ps1
+++ b/FarsightAD.ps1
@@ -9931,7 +9931,7 @@ CSV / JSON file written to disk.
 
         catch {
             Write-Host -ForegroundColor DarkYellow "[Export-ADHuntingACLDefaultFromSchema][-] Error while processing schema class $($SchemaClass.DistinguishedName)"
-            Write-Host -ForegroundColor DarkYellow "[Export-ADHuntingACLDefaultFromSchema][-] defaultSecurityDescriptor is: $SchemaClass["defaultSecurityDescriptor"].Value"
+            Write-Host -ForegroundColor DarkYellow "[Export-ADHuntingACLDefaultFromSchema][-] defaultSecurityDescriptor is: $($SchemaClass["defaultSecurityDescriptor"].Value)"
             Write-Host -ForegroundColor DarkYellow "[Export-ADHuntingACLDefaultFromSchema][-] Exception: $_"
         }
     }


### PR DESCRIPTION
Small PR to correct error handling not displaying the default SD for Schema objects when the parsing function fails.
Before:
![image](https://github.com/Qazeer/FarsightAD/assets/26250556/bf03bd9a-9e0f-4cc9-a9d3-15a2243b0a0d)
After:
![image](https://github.com/Qazeer/FarsightAD/assets/26250556/a4100010-81ab-408e-bf2a-5e0887e259db)
